### PR TITLE
Remove lib/*/** , we ship these files in this fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-lib/**/*
+
 .project
 .settings


### PR DESCRIPTION
Remove the declaration to ignore the files in the lib directory because we do not use the default way to obtain the OpenLayers and jquery files but rather ship our own version of it. With this declaration creating a dist of this repo with the help of composer, our patched versions of OpenLayer and jquery will be missing in the archive. This is used e.G. when you use satis instead of https://packagist.org/.

See: https://github.com/composer/satis/issues/324
https://github.com/composer/composer/issues/3733